### PR TITLE
improve startup option screen

### DIFF
--- a/startup.lua
+++ b/startup.lua
@@ -12,25 +12,74 @@ local bootOptions = {
 local bootOption = 2
 if settings then
 	settings.load('.settings')
-	bootOption = tonumber(settings.get('opus.boot_option') or 2) or 2
+	bootOption = tonumber(settings.get('opus.boot_option')) or bootOption
 end
 
 local function startupMenu()
-	while true do
+	local x, y = term.getSize()
+	local align, selected = 0, 1
+	local function redraw()
+		local title = "Boot Options:"
 		term.clear()
-		term.setCursorPos(1, 1)
-		print('Select startup mode')
-		print()
-		for k,option in pairs(bootOptions) do
-			print(k .. ' : ' .. option.prompt)
-		end
-		print('')
-		term.write('> ')
-		local ch = tonumber(_G.read())
-		if ch and bootOptions[ch] then
-			return ch
+		term.setTextColor(colors.white)
+		term.setCursorPos((x/2)-(#title/2), (y/2)-(#bootOptions/2)-1)
+		term.write(title)
+		for i = 1, #bootOptions do
+			local txt = i..". "..bootOptions[i].prompt
+			term.setCursorPos((x/2)-(align/2), (y/2)-(#bootOptions/2)+i)
+			term.write(txt)
 		end
 	end
+
+	for i = 1, #bootOptions do
+		if (bootOptions[i].prompt):len() > align then
+			align = (bootOptions[i].prompt):len()
+		end
+	end
+
+	redraw()
+	repeat
+		term.setCursorPos((x/2)-(align/2)-2, (y/2)-(#bootOptions/2)+selected)
+		if term.isColor() then
+			term.setTextColor(colors.yellow)
+		else
+			term.setTextColor(colors.lightGray)
+		end
+		term.write(">")
+		local k = ({os.pullEvent()})
+		if k[1] == "mouse_scroll" then
+			if k[2] == 1 then 
+				k = keys.down
+			else
+				k = keys.up
+			end
+		elseif k[1] == "key" then
+			k = k[2]
+		else
+			k = nil
+		end
+		if k then
+			if k == keys.enter or k == keys.right then
+				return selected
+			elseif k == keys.down then 
+				if selected == #bootOptions then 
+					selected = 0 
+				end
+				selected = selected+1 
+			elseif k == keys.up then 
+				if selected == 1 then 
+					selected = #bootOptions+1 
+				end
+				selected = selected-1 
+			elseif k >= keys.one and k <= #bootOptions+1 and k < keys.zero then 
+				selected = k-1
+				return selected
+			end
+			local cx, cy = term.getCursorPos()
+			term.setCursorPos(cx-1, cy)
+			term.write(" ")
+		end
+	until true == false
 end
 
 local function splash()


### PR DESCRIPTION
- Replaced the old startup alternate menu with a cleaner crisper interface
- Up and down arrows as well as the mouse scroll wheel will move the cursor up or down. Enter will proceed to boot.
- OR if the option desired is between 1 and 9, pressing the corresponding key will select and boot that option.
- Appended .lua to the startup file