### PR TITLE
Put pastebin link in the right case (Fixes #40)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,5 @@
 
 ## Install
 ```
-pastebin run uzghlbnc
+pastebin run UzGHLbNC
 ```


### PR DESCRIPTION
Pastebin recently removed support for case-insensitive links with no warning. This puts the original casing of the paste ID in README.md, instead of all-lowercase. Some other things might also need to be changed!