### PR TITLE
Trust manager

### DIFF
--- a/sys/apps/system/trust.lua
+++ b/sys/apps/system/trust.lua
@@ -40,5 +40,14 @@ return UI.Tab {
   enable = function(self)
     self:reload()
     UI.Tab.enable(self)
+  end,
+  eventHandler = function(self, event)
+    if event.type == 'grid_select' then
+      local hosts = Util.readTable('usr/.known_hosts')
+      hosts[event.selected.id] = nil
+      Util.writeTable('usr/.known_hosts', hosts)
+      self:reload()
+      return true
+    end
   end
 }

--- a/sys/apps/system/trust.lua
+++ b/sys/apps/system/trust.lua
@@ -47,7 +47,9 @@ return UI.Tab {
       hosts[event.selected.id] = nil
       Util.writeTable('usr/.known_hosts', hosts)
       self:reload()
-      return true
+    else
+      return UI.Tab.eventHandler(self, event)
     end
+    return true
   end
 }

--- a/sys/apps/system/trust.lua
+++ b/sys/apps/system/trust.lua
@@ -1,0 +1,44 @@
+local UI   = require("opus.ui")
+local Util = require("opus.util")
+local SHA  = require('opus.crypto.sha2')
+
+local function split(s)
+  local b = ""
+  for i = 1, #s, 5 do
+    b = b .. s:sub(i, i+4)
+    if i ~= #s-4 then
+      b = b .. "-"
+    end
+  end
+  return b
+end
+
+return UI.Tab {
+  title = 'Trust',
+  description = 'Manage trusted devices',
+  grid = UI.Grid {
+    x = 2, y = 2, ex = -2, ey = -3,
+    autospace = true,
+    sortColumn = 'id',
+    columns = {
+      { heading = 'Computer ID', key = 'id'},
+      { heading = 'Identity', key = 'pkey'}
+    }
+  },
+  statusBar = UI.StatusBar { values = 'double-click to revoke trust' },
+  reload = function(self)
+    local values = {}
+    for k,v in pairs(Util.readTable('usr/.known_hosts') or {}) do
+      table.insert(values, {
+        id = k,
+        pkey = split(SHA.compute(v):sub(-20):upper()) -- Obfuscate private key for visual ident
+      })
+    end
+    self.grid:setValues(values)
+    self.grid:setIndex(1)
+  end,
+  enable = function(self)
+    self:reload()
+    UI.Tab.enable(self)
+  end
+}


### PR DESCRIPTION
Currently, there isn't a user-friendly way to revoke trusted devices besides editing `/usr/.known_hosts` manually.
The trust manager aims to solve that problem by providing a System panel that allows the user to easily revoke devices with just a click.
Currently there isn't any confirmation dialog, so the user might accidentally revoke a device.

Identities are derived from the last 20 characters of a SHA-256'd private key, used for visual identification.

Some screenshots:
![trust manager item](https://user-images.githubusercontent.com/9440126/90951282-766e0280-e427-11ea-9420-1259fdbbb626.png)
![trust manager panel](https://user-images.githubusercontent.com/9440126/90951254-255e0e80-e427-11ea-8329-7c934a8ac60f.png)
