### PR TITLE
Add a one-time password system

### DIFF
--- a/sys/apps/genotp.lua
+++ b/sys/apps/genotp.lua
@@ -1,0 +1,14 @@
+local SHA = require("opus.crypto.sha2")
+
+local acceptableCharacters = {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"}
+local acceptableCharactersLen = #acceptableCharacters
+   
+local password = ""
+
+for _i = 1, 8 do
+    password = password .. acceptableCharacters[math.random(acceptableCharactersLen)]
+end
+
+os.queueEvent("set_otp", SHA.compute(password))
+
+print("Your one-time password is: " .. password)

--- a/sys/apps/network/trust.lua
+++ b/sys/apps/network/trust.lua
@@ -6,6 +6,22 @@ local Util     = require('opus.util')
 
 local trustId = '01c3ba27fe01383a03a1785276d99df27c3edcef68fbf231ca'
 
+local oneTimePassword -- nil by default
+
+local function validateData(data, password, dhost)
+	local s
+	s, data = pcall(Crypto.decrypt, data, password)
+
+	if s and data and type(data) == "table" and data.pk and data.dh == dhost then
+		local trustList = Util.readTable('usr/.known_hosts') or { }
+		trustList[data.dh] = data.pk
+		Util.writeTable('usr/.known_hosts', trustList)
+		return true
+	else
+		return false
+	end
+end
+
 local function trustConnection(socket)
 	local data = socket:read(2)
 	if data then
@@ -13,17 +29,22 @@ local function trustConnection(socket)
 		if not password then
 			socket:write({ msg = 'No password has been set' })
 		else
-			local s
-			s, data = pcall(Crypto.decrypt, data, password)
-			if s and data and data.pk and data.dh == socket.dhost then
-				local trustList = Util.readTable('usr/.known_hosts') or { }
-				trustList[data.dh] = data.pk
-				Util.writeTable('usr/.known_hosts', trustList)
-
+			if validateData(data, password, socket.dhost) then
+				print("Accepted trust from " .. socket.dhost)
 				socket:write({ success = true, msg = 'Trust accepted' })
-			else
-				socket:write({ msg = 'Invalid password' })
+				return
 			end
+
+			if oneTimePassword then
+				if validateData(data, oneTimePassword, socket.dhost) then
+					print("Accepted trust from " .. socket.dhost .. "using one-time password")
+					socket:write({ success = true, msg = 'Trust accepted - this one-time password will not be usable again' })
+					oneTimePassword = nil -- Make sure nobody can use the one-time password again
+					return
+				end
+			end
+
+			socket:write({ msg = 'Invalid password' })
 		end
 	end
 end
@@ -42,5 +63,14 @@ Event.addRoutine(function()
 			print('Trust error')
 			_G.printError(m)
 		end
+	end
+end)
+
+Event.addRoutine(function()
+	while true do
+		local _event, password = os.pullEvent("set_otp")
+
+		oneTimePassword = password
+		print("got new one-time password")
 	end
 end)


### PR DESCRIPTION
This commit adds a one-time password system. Users can generate
passwords by using the `genotp` command (or manually queuing a set_otp
event with the SHA-256 hash of the one-time password they want to set)
and these passwords will be valid, along with the normal password,
either until the computer shuts down (or the net daemon is killed), a
new one-time password is generated, or the one-time password is used.

This shouldn't conflict with #46. Also, a demo can be found at https://cdn.discordapp.com/attachments/530071845181849630/746867684863377538/OTP_Demo.mov