### PR TITLE
Fix bug so that Lua will display the boolean false correctly

### DIFF
--- a/sys/apps/Lua.lua
+++ b/sys/apps/Lua.lua
@@ -348,7 +348,7 @@ function page:executeStatement(statement)
 	term.redirect(oterm)
 	counter = counter + 1
 
-	if s and m then
+	if s and type(m) ~= "nil" then
 		self:setResult(m)
 	else
 		self.grid:setValues({ })


### PR DESCRIPTION
Currently, when the executed statement results in a false value it will not show any output, this PR fixes this.