### PR TITLE
Change sleep(0) to sleep(0.05) for CraftOS-PC

### DIFF
--- a/sys/modules/opus/ui.lua
+++ b/sys/modules/opus/ui.lua
@@ -1066,7 +1066,7 @@ function UI.Device:runTransitions(transitions)
 		if Util.empty(transitions) then
 			break
 		end
-		os.sleep(0)
+		os.sleep(0.05)
 	end
 end
 


### PR DESCRIPTION
CraftOS-PC handles sleep(0) by not sleeping at all, which makes icon animations go too fast to actually see. Changing this will fix animations in CraftOS-PC, while not changing how it acts in other (more accurate) emulators.