### PR TITLE
Fix #48 (shell resolving issue)

### DIFF
--- a/sys/apps/shell.lua
+++ b/sys/apps/shell.lua
@@ -173,15 +173,12 @@ function shell.resolveProgram(_sCommand)
 		end
 	end
 
-	if not _sCommand:find('/') then
-		return inPath()
-	end
-
 	-- so... even if you are in the rom directory and you run:
 	-- 'packages/common/edit.lua', allow this even though it
 	-- does not use a leading slash. Ideally, fs.combine would
 	-- provide the leading slash... but it does not.
-	return check(shell.resolve(_sCommand))
+	return (not _sCommand:find('/')) and inPath()
+                or check(shell.resolve(_sCommand))
 		or check(shell.resolve(_sCommand) .. '.lua')
 		or check(_sCommand)
 		or check(_sCommand .. '.lua')


### PR DESCRIPTION
42bd4b2 seemingly introduced a bug where programs would not be run from the shell even if they were in the current directory (for example, the program `test/x.lua` would not run if you typed `x` while in the `test` directory). This fixes that by moving the `return inPath()` part into the big `return` statement at the end of `shell.resolvePath`.