### PR TITLE
stopgap fix for opus icons on newer MC

### DIFF
--- a/sys/modules/opus/util.lua
+++ b/sys/modules/opus/util.lua
@@ -177,6 +177,12 @@ function Util.getVersion()
 	end
 	if not version and _G._HOST then
 		version = tonumber(_G._HOST:match('[%d]+%.?[%d][%d]'))
+
+		-- stopgap fix for icons breaking on 1.100.x CC versions
+		-- TODO: Make this cleaner and more resiliant
+		if version == 1.1 then
+			version = 1.999
+		end
 	end
 
 	return version or 1.7


### PR DESCRIPTION
Opus `Utils.getVersion` results in returning `1.1` rather than anything newer when on the 1.100.x CC versions (fabric and forge)

this is an stop gap fix, and yes, If I knew how I would tweak the matchers to make it work, but I dont so this will do, because whoever is on CC 1.1... needs to get off it,